### PR TITLE
Tilegrid viewport fix

### DIFF
--- a/src/tilegrid.coffee
+++ b/src/tilegrid.coffee
@@ -204,7 +204,7 @@ module.exports = class Tilegrid
     topIndex = viewStats.topDisplayIndex
     bottomIndex = viewStats.bottomDisplayIndex
 
-    return unless topIndex? && bottomIndex?
+    return unless topIndex? && bottomIndex? && (topIndex != 0 || bottomIndex != 0)
     @updateCollectionViewStats topDisplayIndex: topIndex + 1, bottomDisplayIndex: bottomIndex + 1
 
     @topRenderIndex = Math.max(topIndex - @options.pageSize, 0)


### PR DESCRIPTION
Tilegrid viewport fix - User reported  (https://jira.corp.zulily.com/browse/SDSEA-479729) an issue where after 1000 styles in the instock curator, they would start seeing random people's styles.  What was happening was after that 1000th element, UI was making a call without any filters with reset paging, which returned back random styles.

Diving deeper, I saw what was initiating that call was the tilegrid trying to load styles 1-50, which is strange since it already had the first 1000 loaded.  I traced the problem to this line, where getViewingStats would call _getGridScrollDims and find that the grid's dimensions were:  {top:0, left:0, bottom:0, right:0, height:0, width:0} and thus respond with topIndex=0 and bottomIndex=0.

My change is to make tileGrid not do a collection fetch for 0-to-0.